### PR TITLE
文章页时间跟随主配置；移除文章 meta 最后一个元素后的斜杠

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 yarn.lock
 acelog.js.map

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -22,7 +22,7 @@
                     </h1>
                     <div class="al_page_info dis_flex">
                         <div class="al_page_content_info">
-                            {{ page.date|date('F d, Y h:m A') }}
+                            {{ page.date.format("MMMM DD, Y h:m A") }}
                         </div>
 
                         {% if wordcount %}

--- a/source/stylus/_page.styl
+++ b/source/stylus/_page.styl
@@ -69,13 +69,16 @@
 
 .al_page_content_info {
     margin-right: 15px;
-    &::after {
-        content: "/";
-        right: -7px;
-        position: relative;
-    }
     font-size: 13px;
     color: #888;
+
+    &:not(:last-of-type) {
+        &::after {
+            content: "/";
+            right: -7px;
+            position: relative;
+        }
+    }
 }
 
 .al_disqus {


### PR DESCRIPTION
## 时间显示跟随主配置

- 修复了时区问题
- 格式还是尊重了原来的顺序和格式

## 样式修改附图

### 修改前
![image](https://user-images.githubusercontent.com/57994127/104884832-f6ca6c80-59a1-11eb-8e2f-560ae2622823.png)

### 挪去后好看多啦
![image](https://user-images.githubusercontent.com/57994127/104884902-15306800-59a2-11eb-8cd5-20ee9d0464e5.png)
