### PR TITLE
一组优化和修复：时区、文章 meta、favicon 与 manifest、gitalk 插件等

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 yarn.lock
 acelog.js.map

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can modify the main color to your prefer one, which in `$theme_color` in `th
 ### Favicon:
 
 [favicon.io](https://favicon.io) is the recommended favicon generation tool:
-just generate, download, got `favicon.io.zip`, and unzip to your `source` directory.
+just generate, download, got `favicon_io.zip`, and unzip to your `source` directory.
 
 
 ### IPC License:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You can modify the main color to your prefer one, which in `$theme_color` in `th
 ### Favicon:
 
 [favicon.io](https://favicon.io) is the recommended favicon generation tool:
-just generate, download, got `favicon.io.zip`, and unzip to you `source`.
+just generate, download, got `favicon.io.zip`, and unzip to your `source` directory.
 
 
 ### IPC License:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ You can change the color you prefer in `themes/Acetolog/source/stylus/_var.styl`
 
 You can modify the main color to your prefer one, which in `$theme_color` in `themes/Acetolog/source/stylus/_var.styl`.
 
+
+### Favicon:
+
+[favicon.io](https://favicon.io) is the recommended favicon generation tool:
+just generate, download, got `favicon.io.zip`, and unzip to you `source`.
+
+
 ### IPC License:
 
 You can enable it in theme config `themes/Acetolog/_config.yml`, chinese website may need it.

--- a/layout/includes/head.swig
+++ b/layout/includes/head.swig
@@ -1,9 +1,9 @@
 <title>{{ page.title || config.subtitle || '' }}</title>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=2.0">
-<link rel="stylesheet", href="{{ url_for('css/style.css') }}">
-<link rel="shortcut icon", href="{{ url_for('favicon.ico') }}">
-<link rel="apple-touch-icon", href="{{ url_for('apple-touch-icon.png') }}">
-<link rel="icon", type: 'image/png', sizes: '16x16', href="{{ url_for('favicon-16x16.png') }}">
-<link rel="icon", type: 'image/png', sizes: '32x32', href="{{ url_for('favicon-32x32.png') }}">
+<link rel="stylesheet" href="{{ url_for('css/style.css') }}">
+<link rel="shortcut icon" href="{{ url_for('favicon.ico') }}">
+<link rel="apple-touch-icon" href="{{ url_for('apple-touch-icon.png') }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('favicon-16x16.png') }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('favicon-32x32.png') }}">
 <link rel="manifest" href="{{ url_for('site.webmanifest') }}">

--- a/layout/includes/head.swig
+++ b/layout/includes/head.swig
@@ -1,6 +1,9 @@
 <title>{{ page.title || config.subtitle || '' }}</title>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=2.0">
-<link rel="stylesheet", href="{{ url_for('./css/style.css') }}">
-<link rel="shortcut icon", href="{{ url_for('./favicon.ico') }}">
-<link rel="apple-touch-icon", href="{{ url_for('./apple-touch-icon.png') }}">
+<link rel="stylesheet", href="{{ url_for('css/style.css') }}">
+<link rel="shortcut icon", href="{{ url_for('favicon.ico') }}">
+<link rel="apple-touch-icon", href="{{ url_for('apple-touch-icon.png') }}">
+<link rel="icon", type: 'image/png', sizes: '16x16', href="{{ url_for('favicon-16x16.png') }}">
+<link rel="icon", type: 'image/png', sizes: '32x32', href="{{ url_for('favicon-32x32.png') }}">
+<link rel="manifest" href="{{ url_for('site.webmanifest') }}">

--- a/layout/includes/plugins/gitalk.swig
+++ b/layout/includes/plugins/gitalk.swig
@@ -1,5 +1,5 @@
 {%  if theme.gitalk.enable %}
-    <div id="al_gitalk_cnt">
+    <div id="al_gitalk_cnt" />
     <script src="//cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
     <script>
         var gitalk = new Gitalk({

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -22,7 +22,7 @@
                     </h1>
                     <div class="al_page_info dis_flex">
                         <div class="al_page_content_info">
-                            {{ page.date.format('ddd MMMM DD, Y h:m A') }}
+                            {{ page.date.format('ddd MMMM DD, Y hh:mm A') }}
                         </div>
 
                         {% if wordcount %}

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -22,7 +22,7 @@
                     </h1>
                     <div class="al_page_info dis_flex">
                         <div class="al_page_content_info">
-                            {{ page.date.format('ddd MMMM DD, Y hh:mm A') }}
+                            {{ page.date.format('ddd MMMM D, Y hh:mm A') }}
                         </div>
 
                         {% if wordcount %}

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -22,7 +22,7 @@
                     </h1>
                     <div class="al_page_info dis_flex">
                         <div class="al_page_content_info">
-                            {{ page.date|date('F d, Y h:m A') }}
+                            {{ page.date.format("MMMM DD, Y h:m A") }}
                         </div>
 
                         {% if wordcount %}

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -22,7 +22,7 @@
                     </h1>
                     <div class="al_page_info dis_flex">
                         <div class="al_page_content_info">
-                            {{ page.date.format("MMMM DD, Y h:m A") }}
+                            {{ page.date.format("ddd MMMM DD, Y h:m A") || date.format("ddd MMMM DD, Y h:m A") }}
                         </div>
 
                         {% if wordcount %}

--- a/layout/post.swig
+++ b/layout/post.swig
@@ -22,7 +22,7 @@
                     </h1>
                     <div class="al_page_info dis_flex">
                         <div class="al_page_content_info">
-                            {{ page.date.format("ddd MMMM DD, Y h:m A") || date.format("ddd MMMM DD, Y h:m A") }}
+                            {{ page.date.format('ddd MMMM DD, Y h:m A') }}
                         </div>
 
                         {% if wordcount %}

--- a/source/stylus/_page.styl
+++ b/source/stylus/_page.styl
@@ -69,13 +69,16 @@
 
 .al_page_content_info {
     margin-right: 15px;
-    &::after {
-        content: "/";
-        right: -7px;
-        position: relative;
-    }
     font-size: 13px;
     color: #888;
+
+    &:not(:last-of-type) {
+        &::after {
+            content: "/";
+            right: -7px;
+            position: relative;
+        }
+    }
 }
 
 .al_disqus {


### PR DESCRIPTION
我，喜欢，你的，主题。

做一点儿绵薄的贡献吧：

## 此 PR 包含的更新

1. 修复：文章页显示时区跟随主配置，避免内外（post vs. index）显示不一致
2. 优化：文章页移除 `meta` 最后一个元素后的斜杠
3. 优化：为模板页面 `head` 添加 `webmanifest`（源自 https://favicon.io 工具）
4. 更新：`README.md` 添加了 `favicon` 的说明
5. 优化：将 `layout/includes/plugins/gitalk.swig` 中 `#al_gitalk_cnt` 元素的 `div` 标签完成关闭
6. 顺带：`.gitignore` 为 `JetBrains` 家族的 IDE 添加了 `.idea` 行


## 截图对比：

### 原：
![image](https://user-images.githubusercontent.com/57994127/104886853-5d04be80-59a5-11eb-89cf-f5518a82b17d.png)

### 新：
![image](https://user-images.githubusercontent.com/57994127/104935082-c3113600-59e5-11eb-85a7-24f1e1743ba9.png)

