### PR TITLE
优化：_pageContent 里辅助色不跟随主题色变化 - 增加主题辅助色

### DIFF
--- a/source/stylus/_pageContent.styl
+++ b/source/stylus/_pageContent.styl
@@ -19,7 +19,7 @@ article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,secti
 
 u {
 	text-decoration: none;
-	background-image: linear-gradient(to bottom, rgba(0,0,0,0) 50%,#e06e73 50%);
+	background-image: linear-gradient(to bottom, rgba(0,0,0,0) 50%, $theme_color_light 50%);
 	background-repeat: repeat-x;
 	background-size: 2px 2px;
 	background-position: 0 1.05em
@@ -42,7 +42,7 @@ blockquote {
 	display: block;
 	margin-left: -1em;
 	padding-left: 0.8em;
-	border-left: 0.2em solid #e06e73
+	border-left: 0.2em solid $theme_color_light;
 }
 
 .arrow svg #rod {
@@ -76,7 +76,7 @@ figure.highlight {
         border: none;
         padding: 0;
 	}
-	
+
 	td.gutter {
 		text-align: right;
 
@@ -112,7 +112,7 @@ code:not(.hljs) {
 
 #post-body > ul, #post-body > ol {
 	padding-inline-start: 0px;
-	
+
 	li {
 		margin-bottom: 5px;
 	}
@@ -136,7 +136,7 @@ code:not(.hljs) {
 	}
 }
 
-ol { 
+ol {
 	counter-reset: ol 0;
 	li {
 		display: block;

--- a/source/stylus/_var.styl
+++ b/source/stylus/_var.styl
@@ -2,6 +2,7 @@
 
 // This is the MAIN THEME COLOR.
 $theme_color = #be223a;
+$theme_color_light = #e06e73;
 
 // Light mode color set.
 


### PR DESCRIPTION
- 在 `_var.styl` 里添加 `$theme_color_light` 变量
- 新加的变量值设置为原辅助色值 `#e06e73`
- 修改 `_pageContent.styl` 里直接指定 `#e06e73` 色值的两处，换为新增的 `$theme_color_light` 变量
- 其它删空格之类的动作是 IDE 自动完成的